### PR TITLE
Convert word doc to Markdown

### DIFF
--- a/OSM_Series_4_Paper1.md
+++ b/OSM_Series_4_Paper1.md
@@ -1,0 +1,116 @@
+[Series 4 Paper 1 Title]
+
+[Authors]
+
+[Abstract]
+
+[Graphical Abstract]
+
+[Background to Malaria]
+
+[Discovery of Series 4 and subsequent development story]
+
+Results and Discussion
+
+**Synthetic Approaches to the TP Series**
+
+[Summary of Organic Synthesis]
+
+**Modification of the Triazolopyrazine Core**
+
+Modification of the triazole ring was explored through the synthesis of
+the imidazo[1,2-a]pyrazine MMV669846 and the imidazo[1,5-a]pyrazine
+MMV670250 and comparison with the parent [1,2,4]triazole[4,3-a]pyrazine
+MMV639565 (Figure X). Such changes gave moderate decreases in potency
+(vs. PfNF54) and, particularly for MMV670250, a significant worsening in
+metabolic stability. The reasonable potency of MMV669846 suggests that
+the 2-position of this compound could be a point of attachment for
+functional groups (*e.g.,* biotinylated chains) that might assist in
+mechanism of action studies. The ring system in MMV669846 is the same as
+that in the similar-looking Novartis series based around
+KAI409,[10.1038/nature12782] but the mechanism of action of that
+compound targets PI4K and not PfATP4.
+
+![](https://raw.githubusercontent.com/OpenSourceMalaria/OSMSeries4Paper1/master/Schemes/Core%20Mods%20Triazole.png)
+<img src="https://raw.githubusercontent.com/OpenSourceMalaria/OSMSeries4Paper1/master/Schemes/Core%20Mods%20Triazole.png" width="300px">
+
+**Figure X**. Effect on Potency and Metabolic Stability of Altering the
+Triazole Portion of the Triazolopyrazine Core (Units)
+
+Modifications to the pyrazine ring generally gave reductions in potency
+(Figure X) – several aromatic and aliphatic analogs have been evaluated.
+The transposed analog MMV672942 retained some activity (though the ether
+analog MMV672939 did not).
+
+<img src="https://raw.githubusercontent.com/OpenSourceMalaria/OSMSeries4Paper1/master/Schemes/Core%20Mods%20Pyrazine%20Combined.png" width="300px">
+
+**Figure X**. Effect on Potency of Alterations in the Pyrazine Ring of
+the Triazolopyrazine Core.
+
+**Modifications of the Triazolopyrazine Core Substituents**
+
+With the triazolopyrazine scaffold established as the leading
+heterocyclic core for this series of compounds, variations were made in
+the substituents and their attachment pattern. Several compounds were
+evaluated bearing substitution in the 8-position (as a potential block
+for aldehyde oxidase activity, see below); only the analog possessing a
+reactive α-chloro azaaromatic group (MMV668823) retained any significant
+potency. Analogs have not yet been evaluated with corresponding
+substituents in the 6-position. However, several compounds with
+transposed side chains were synthesized which in most cases exhibited
+reduced potency compared to closely related compounds lacking such a
+change. The exceptions were compounds containing ether-linked chains
+with a one-or two-carbon spacer, for example MMV670945 (though this
+compound displayed rapid metabolism in a rat liver microsome assay. In
+general substitution in the 5-position was prioritized for follow-up.
+
+
+<img src="https://raw.githubusercontent.com/OpenSourceMalaria/OSMSeries4Paper1/master/Schemes/TP%20Core%20Substituents%20Combined.png" width="300px">
+
+**Figure X**. Modifications to the Pyrazine Substituents and Comparisons
+with Closely Related Compounds (RLM Cl units are mL/min/kg)
+
+Many compounds in this series displaying high potency possess aromatic
+substituents directly linked to the triazole ring in the TP core. Nine
+compounds were synthesized possessing aliphatic substituents in this
+position, or aromatic groups linked via a heteroatom, or a pyrazole. All
+exhibited greatly reduced potency compared to analogous compounds,
+though further exploration of aliphatic and heteroaromatic groups in
+this position remain a promising line of enquiry given that there is
+significant unexplored chemical space and that a reduction in the number
+of aromatic groups in the TP series should help increase compound
+solubility. However, priority was given to further optimization of
+aromatic functionality directly attached to the triazole in this
+position.
+
+<img src="https://raw.githubusercontent.com/OpenSourceMalaria/OSMSeries4Paper1/master/Schemes/Cycloaliphatic%20Triazole%20Subst%20v2.png" width="300px">
+
+**Figure X**. Variation in the Structure of the Aromatic Substituent on
+the Triazole Ring of the TP Core.
+
+**Variation in Ether-linked Substituent in the 5-Position**
+
+Several analogs were explored with variation in the ether substituent at
+the 5-position, while retaining the 4-(difluoromethoxy)phenyl group
+directly attached to the triazole ring (Figure X). Potent compounds were
+observed with phenethylether side chains, but given the propensity for
+such compounds to act as metabolic hotspots significant variation was
+explored in the structure of this substituent. In general a range of
+variations was tolerated, including those with polar functional groups
+in the benzylic position (of note is the alcohol MMV670947 at 24 nM and
+the amine MMV670437 at 44 nM). The primary amine analog of MMV670437
+(MMV671651) remained potent (as did the morpholine analog MMV671647 to a
+lesser extent), while the monomethyl analog MMV670763 exhibited greatly
+reduced potency. A single analog with substitution on both carbon atoms
+of the phenethyl methylenes (MMV672626) exhibited low potency. Side
+chain lengths other than three atoms generally gave lower potencies. The
+2-naphthol analog MMV670659 gave reasonable potency but poor stability
+in a rat liver microsome assay (we lack the number). While not potent
+the phenol-substituted analog MMV669784 exhibited favourable metabolic
+clearance rates (see below).
+
+**Figure X**. Measured Potencies of TP Analogs with 4-(CHF2)O-phenyl
+Attached Directly to the Triazole Ring with Variation in the Ether
+Substituent in the 5-Position (Assay for OSM-S-260 possibly different
+from others)
+


### PR DESCRIPTION
This converts the paper from a Word document into Markdown so that it is readily renderable.